### PR TITLE
Allow multiple "defaultBranches" called stableBranches

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ buildscript {
 // Optional: configure the versioner
 ext.gitVersioner = [
         defaultBranch           : "develop",  // default "master"
+        stableBranches          : ["master", "someOtherBranch"], // default [], the feature branch postfix (-dm4(6)) will not be appended on stable branches, all commits are included into the version number calculation
         yearFactor              : 1200, 	  // default "1000", increasing every 8.57h
         snapshotEnabled         : false,      // default false, the "-SNAPSHOT" postfix
         localChangesCountEnabled: false       // default false, the (<commitCount>) before -SNAPSHOT

--- a/git-versioner.gradle
+++ b/git-versioner.gradle
@@ -64,6 +64,7 @@ def GitVersion generateVersionName() {
 
     // read ext properties
     Map configuration = getPropertyOrDefault(rootProject, "gitVersioner", [:]) as Map
+    def String[] stableBranches = configuration.get("stableBranches") ?: []
     def defaultBranch = configuration.get("defaultBranch") ?: "master"
     float yearFactor = (configuration.get("yearFactor") ?: "1000").toString().toFloat()
     boolean snapshotEnabled = configuration.get("snapshotEnabled") ?: true
@@ -71,6 +72,11 @@ def GitVersion generateVersionName() {
 
     // get information from git
     def currentBranch = 'git symbolic-ref --short -q HEAD'.execute([], rootDir).text.trim()
+
+    // use a defined stable branch when on such a branch
+    if (stableBranches.contains(currentBranch)) {
+        defaultBranch = currentBranch
+    }
     def currentCommit = 'git rev-parse HEAD'.execute([], rootDir).text.trim()
 
     def log = "git log --pretty=format:'%at' --reverse".execute([], rootDir)


### PR DESCRIPTION
Those branches are so stable that all commits will be included into the version and there is no second part `-ba2(5)` as on feature branches
