### PR TITLE
Allow consumers to determine stable branches at build time using regex

### DIFF
--- a/git-versioner.gradle
+++ b/git-versioner.gradle
@@ -75,6 +75,7 @@ def GitVersion generateVersionName() {
     // read ext properties
     Map configuration = getPropertyOrDefault(rootProject, "gitVersioner", [:]) as Map
     def String[] stableBranches = configuration.get("stableBranches") ?: []
+    def isStableBranchClosure = configuration.get("isStableBranch") ?: {}
     def defaultBranch = configuration.get("defaultBranch") ?: "master"
     float yearFactor = (configuration.get("yearFactor") ?: "1000").toString().toFloat()
     boolean snapshotEnabled = configuration.get("snapshotEnabled") != false
@@ -85,7 +86,7 @@ def GitVersion generateVersionName() {
     def currentBranch = 'git symbolic-ref --short -q HEAD'.execute([], rootDir).text.trim()
 
     // use a defined stable branch when on such a branch
-    if (stableBranches.contains(currentBranch)) {
+    if (stableBranches.contains(currentBranch) || isStableBranchClosure(currentBranch)) {
         defaultBranch = currentBranch
     }
     def currentCommit = 'git rev-parse HEAD'.execute([], rootDir).text.trim()
@@ -96,8 +97,6 @@ def GitVersion generateVersionName() {
     def localChangesCount = 'git diff-index HEAD'.execute([], rootDir).text.trim().readLines().
             size()
     boolean hasLocalChanges = localChangesCount > 0
-
-
 
     def diffToDefault = "git rev-list $defaultBranch..".execute([], rootDir)
     diffToDefault.waitFor()


### PR DESCRIPTION
Adds a call to a new configuration closure named `isStableBranch` to allow consumers of the script to determine if a branch is stable when running a build. This is helpful for stable branches that may be dynamic in some way and need to be checked via regex. An example would be release branches, something like `release-v4.5`.

Ex. implementation:
```groovy
ext.gitVersioner = [
  isStableBranch: { branch ->
    switch(branch) {
       case 'master': return true
       case ~/release-[\w\W]*/: return true
       default: return false
    }
  }
]
```